### PR TITLE
feat: talks translations to french

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "bulma": "^0.7.0",
+    "bulma-switch": "^2.0.0",
     "gatsby": "^2.1.34",
     "gatsby-image": "^2.0.23",
     "gatsby-plugin-netlify": "^2.0.6",
@@ -34,6 +35,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-helmet": "^5.2.0",
+    "showdown": "^1.9.0",
     "uuid": "^3.2.1"
   },
   "keywords": [

--- a/src/cms/preview-templates/TalksPostPreview.js
+++ b/src/cms/preview-templates/TalksPostPreview.js
@@ -5,10 +5,13 @@ import { TalksPostTemplate } from '../../templates/talks-post'
 const TalksPostPreview = ({ entry, widgetFor }) => (
   <TalksPostTemplate
     content={widgetFor('body')}
+    contentfr={entry.getIn(['data', 'bodyfr'])}
     description={entry.getIn(['data', 'description'])}
+    descriptionfr={entry.getIn(['data', 'descriptionfr'])}
     tags={entry.getIn(['data', 'tags'])}
     title={entry.getIn(['data', 'title'])}
     talktitle={entry.getIn(['data', 'talktitle'])}
+    talktitlefr={entry.getIn(['data', 'talktitlefr'])}
   />
 )
 

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -132,7 +132,11 @@ $menu-label-color: $white-ter
 
 @import "~bulma"
 @import "~bulma/sass/elements/table.sass"
+@import '~bulma-switch';
 
+.switch.is-primary[type=checkbox]:checked + label::before,
+.switch.is-primary[type=checkbox]:checked + label:before,
+  background-color: $primary;
 
 // responsiveness
 +tablet-only

--- a/src/pages/talks/prpl-pattern.md
+++ b/src/pages/talks/prpl-pattern.md
@@ -2,6 +2,7 @@
 templateKey: talks-post
 title: P.R.P.L Pattern
 talktitle: "\U0001F9B8‍♂️PRPL: it’s time to learn up with the Fantastic Four!"
+talktitlefr: "Il est temps de rejoindre les 4 fantastiques du Web : Push, Render, Pre-cache & Lazy-load !"
 date: 2019-05-05T15:21:42.938Z
 featuredpost: true
 description: The Web Performance pattern you should already know!
@@ -14,6 +15,24 @@ tags:
   - webdev
   - web performance
   - HTTP/2
+bodyfr: |
+  Le PRPL Pattern, tu connais ?
+
+  Non ? Pour faire court, c'est juste LE pattern à mettre en place sur vos Web App pour de bonnes performances, en mettant à profit les dernières technos du web moderne comme l'HTTP/2, preload, les Services Workers ou encore les ES modules.
+
+  Sinon, c'est que tu as sans doute déjà lu un article par ci par là. Tu as peut-être alors trouvé ça vachement cool et novateur, mais bon, de là à le mettre en place dans le monde réel ... ça a quand même l'air sacrément compliqué.
+
+  Eh bien figure toi que non ! Avec des outils comme PRPL-Server par exemple, rien de plus simple !
+
+  Du coup, ça te dit une démo, un pas à pas, et quelques approfondissements sur les technos sous-jascentes ? Alors on y va !
+
+  ## Détails
+
+  Talk présenté au Best of Web 2019 (http://bestofweb.paris/).
+
+  Approfondissement du chapitre "Fast" (performance) de l'université "The Web is still on F.I.R.E." (faire le point sur le PWA en 2019) que j'ai donné au BreizhCamp 2019 (https://youtu.be/OQ-dr-7pLaA?t=1643 & https://www.breizhcamp.org/conference/programme/).
+
+  Voir le projet associé (en perpétuelle évolution), slides inclus : https://github.com/noelmace/web-on-fire
 ---
 Do you know about the PRPL Pattern?
 

--- a/src/pages/talks/vanillajs-state-of-the-art.md
+++ b/src/pages/talks/vanillajs-state-of-the-art.md
@@ -5,6 +5,7 @@ talktitle: "Brace yourself, \U0001F366Vanilla is coming … back \U0001F576!"
 date: 2019-07-08T12:43:57.489Z
 featuredpost: true
 description: Embrace the power of the Web Platform! A real-life practical guide.
+descriptionfr: Enfin un guide pratique pour utiliser les Web Components dans la vraie vie !
 authors:
   - Noël Macé
 type: conference (30-45min)
@@ -13,6 +14,25 @@ selectedat:
 tags:
   - webdev
   - web components
+bodyfr: |
+  Dans un monde de saveurs complexes et sophistiquées, la guerre du toping fait rage à Web-steros ! Face au champs de bataille, les pronostiques vont bon train pour savoir qui l’emportera entre le crunchy Angulaire, le fondant Reactifs et le décoratif Vue. Durant ce temps, loin de ces vicissitudes, la petite saveur basique vanille avance encore et toujours vers son destin. S’agirait-il du héro de la légende, susceptible de renverser le destin de ce monde sans heurts ?
+
+  Sache, voyageur, qu’elle est déjà passée par nos contrées. Viens, et écoute son histoire. Laisse moi te raconter comment elle nous a permis de renverser notre vieux roi, et tu saura enfin ce qui se prépare pour ton royaume.
+
+  ## Détails
+
+  Retour d’expérience (notamment) sur notre migration progressive d’app complexe (avec entre autre du AngularJS, et oui…) vers du vanilla chez BonitaSoft.
+
+  Dans la tendance actuelle de remettre en cause l’omniprésence des frameworks web, je m’attache durant ce talk à présenter les nouvelles approches possibles en vanilla.
+
+  Principaux éléments :
+
+  ce que les nouveaux standards apportent
+  - faire des web components à haut niveau : interactions, maintenabilité et performances
+  - les micro-librairies du moment (notamment lit-element, lit-html et pwa-helpers) et leur utilité
+  - routing
+  - state management
+  - tests
 ---
 
 In a world of complex and sophisticated flavors, the battle for toppings among

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -14,16 +14,19 @@ collections:
     fields:
       - {label: "Template Key", name: "templateKey", widget: "hidden", default: "talks-post"}
       - {label: "Generic Title", name: "title", widget: "string"}
-      - {label: "Talk Title", name: "talktitle", widget: "string"}
+      - {label: "Talk Title", name: "talktitle", widget: "string", required: false}
+      - {label: "Talk Title (fr)", name: "talktitlefr", widget: "string", required: false}
       - {label: "Publish Date", name: "date", widget: "datetime"}
-      - {label: "Featured", name: "featuredpost", widget: "boolean"}
-      - {label: "Short Summary", name: "description", widget: "text"}
+      - {label: "Featured", name: "featuredpost", widget: "boolean", required: false}
+      - {label: "Short Summary", name: "description", widget: "text", required: false}
+      - {label: "Short Summary (fr)", name: "descriptionfr", widget: "text", required: false}
       - {label: "Author(s)", name: "authors", widget: "list"}
       - {label: "Type", name: "type", widget: "select", options: ["conference (30-45min)", "quicky (15min)", "lightning (5min)", "Deep dive (2-3h)", "Workshop"]}
-      - {label: "Abstract, details & notes", name: "body", widget: "markdown"}
       - {label: "Selected At", name: "selectedat", widget: "list", required: false}
       - {label: "Presented At", name: "presentedat", widget: "list", required: false}
       - {label: "Tags", name: "tags", widget: "list"}
+      - {label: "Abstract, details & notes", name: "body", widget: "markdown"}
+      - {label: "Résumé, détails & notes (fr)", name: "bodyfr", widget: "markdown", required: false}
   - name: "pages"
     label: "Pages"
     files:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2647,6 +2647,11 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
+bulma-switch@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bulma-switch/-/bulma-switch-2.0.0.tgz#7a187cd1bb8073e9a542478d936b89315f1ffcd8"
+  integrity sha512-myD38zeUfjmdduq+pXabhJEe3x2hQP48l/OI+Y0fO3HdDynZUY/VJygucvEAJKRjr4HxD5DnEm4yx+oDOBXpAA==
+
 bulma@^0.7.0:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.5.tgz#35066c37f82c088b68f94450be758fc00a967208"
@@ -12711,6 +12716,13 @@ shell-quote@1.6.1, shell-quote@^1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
+showdown@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/showdown/-/showdown-1.9.0.tgz#d49d2a0b6db21b7c2e96ef855f7b3b2a28ef46f4"
+  integrity sha512-x7xDCRIaOlicbC57nMhGfKamu+ghwsdVkHMttyn+DelwzuHOx4OHCVL/UW/2QOLH7BxfCcCCVVUix3boKXJKXQ==
+  dependencies:
+    yargs "^10.0.3"
+
 sift@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/sift/-/sift-5.1.0.tgz#1bbf2dfb0eb71e56c4cc7fb567fbd1351b65015e"
@@ -14974,6 +14986,13 @@ yargs-parser@^7.0.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+  integrity sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs@12.0.5, yargs@^12.0.5:
   version "12.0.5"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
@@ -14991,6 +15010,24 @@ yargs@12.0.5, yargs@^12.0.5:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yargs@^10.0.3:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
+  integrity sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^8.1.0"
 
 yargs@^13.2.2:
   version "13.2.4"


### PR DESCRIPTION
Close #1

**What kind of change does this PR introduce?**

Allow showing description, title, and body translation in French for talks, using dedicated fields in their frontmatters.

As Gatsby doesn't, by default, know how to convert a markdown in a frontmatter to HTML, I here used a dedicated runtime library, showdown,
as suggested by @blakenoll in https://github.com/gatsbyjs/gatsby/issues/5021#issuecomment-426688625.

This isn't the best choice for performance. Trying to do this directly using Gatby would be way better.

**Does this PR introduce a breaking change?**

No, because all the new related fields are optional. But we need to add those in our current drafts (#2 & #3).
